### PR TITLE
Add Home Assistant config flow for UI-based integration setup

### DIFF
--- a/HACS_INSTALLATION.md
+++ b/HACS_INSTALLATION.md
@@ -93,11 +93,34 @@ id_token: eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6Ik5qSTBO...
 account_id: 30264061
 ```
 
-### Step 4: Configure Integration
+### Step 4: Add Integration via UI
 
-**Option A: configuration.yaml (Simple)**
+**Now you can add the integration through the Home Assistant UI:**
 
-Edit your `configuration.yaml`:
+1. **Go to Settings**
+   - Navigate to **Settings → Devices & Services**
+
+2. **Add Integration**
+   - Click **"+ Add Integration"** in the bottom right
+   - Search for **"OVO Energy Australia"**
+   - Click on it to start setup
+
+3. **Enter Credentials**
+   - **Access Token:** Paste your access_token (with "Bearer " prefix)
+   - **ID Token:** Paste your id_token
+   - **Account ID:** Enter your account ID
+
+4. **Submit**
+   - Click **"Submit"**
+   - The integration will validate your credentials
+
+5. **Done!**
+   - Your sensors should now appear in Developer Tools → States
+   - Look for entities starting with `sensor.ovo_energy_`
+
+---
+
+### Alternative: configuration.yaml (Legacy)
 
 ```yaml
 ovo_energy_au:

--- a/README.md
+++ b/README.md
@@ -118,8 +118,7 @@ Pre-built custom component with 5 sensors:
 
 - ⚠️ **OAuth Success Rate** - May not work for all Auth0 configurations (fallback to manual tokens available)
 - ⚠️ **Account ID** - May need to be entered manually after OAuth login
-- ⚠️ **Home Assistant YAML Configuration Only** - No UI config flow (can use manual tokens)
-- ⚠️ **Blocking I/O in HA Component** - Should be async
+- ⚠️ **Token Lifespan** - Tokens expire every 5 minutes and need manual refresh in Home Assistant
 - ⚠️ **Only Tested with Solar Accounts** - Non-solar accounts untested
 
 ### 🎯 Roadmap
@@ -128,11 +127,13 @@ Pre-built custom component with 5 sensors:
 - [x] Implement OAuth 2.0 authentication flow with PKCE
 - [x] Automatic token refresh mechanism
 
+**Recently Completed:** ✅
+- [x] Home Assistant config flow (UI setup)
+
 **High Priority:**
 - [ ] Improve OAuth compatibility (test with more account types)
 - [ ] Auto-detect account ID after OAuth login
-- [ ] Home Assistant config flow (UI setup)
-- [ ] Async/await implementation for HA
+- [ ] Automatic token refresh in Home Assistant
 
 **Medium Priority:**
 - [ ] Additional GraphQL queries (billing, account details)
@@ -555,6 +556,16 @@ This project is licensed under the MIT License - see [LICENSE](LICENSE) file for
 ---
 
 ## Changelog
+
+### [0.2.2] - 2026-01-20
+
+**Home Assistant Config Flow Release**
+- ✅ **NEW:** Home Assistant config flow for UI-based setup
+- ✅ **NEW:** No more YAML configuration required
+- ✅ **NEW:** Add integration directly from Settings > Devices & Services
+- ✅ **FIXED:** Sensors now appear in Developer Tools
+- ✅ Added strings.json for proper UI labels
+- ✅ Improved integration validation
 
 ### [0.2.0] - 2026-01-20
 

--- a/custom_components/ovo_energy_au/config_flow.py
+++ b/custom_components/ovo_energy_au/config_flow.py
@@ -1,0 +1,89 @@
+"""Config flow for OVO Energy Australia integration."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.exceptions import HomeAssistantError
+
+from .const import DOMAIN, CONF_ACCESS_TOKEN, CONF_ID_TOKEN, CONF_ACCOUNT_ID
+from .ovo_client import OVOEnergyAU, OVOAPIError
+
+_LOGGER = logging.getLogger(__name__)
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_ACCESS_TOKEN): str,
+        vol.Required(CONF_ID_TOKEN): str,
+        vol.Required(CONF_ACCOUNT_ID): str,
+    }
+)
+
+
+async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
+    """Validate the user input allows us to connect.
+
+    Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
+    """
+    # Create client and test authentication
+    client = OVOEnergyAU(account_id=data[CONF_ACCOUNT_ID])
+    client.set_tokens(data[CONF_ACCESS_TOKEN], data[CONF_ID_TOKEN])
+
+    try:
+        # Test the connection by fetching data
+        await hass.async_add_executor_job(client.get_today_data)
+    except OVOAPIError as err:
+        _LOGGER.error("Failed to authenticate with OVO Energy API: %s", err)
+        raise InvalidAuth from err
+    except Exception as err:
+        _LOGGER.exception("Unexpected exception during validation")
+        raise CannotConnect from err
+
+    # Return info to be stored in the config entry
+    return {"title": f"OVO Energy AU ({data[CONF_ACCOUNT_ID][:8]}...)"}
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for OVO Energy Australia."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            try:
+                info = await validate_input(self.hass, user_input)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                # Create a unique ID based on account ID to prevent duplicates
+                await self.async_set_unique_id(user_input[CONF_ACCOUNT_ID])
+                self._abort_if_unique_id_configured()
+
+                return self.async_create_entry(title=info["title"], data=user_input)
+
+        return self.async_show_form(
+            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )
+
+
+class CannotConnect(HomeAssistantError):
+    """Error to indicate we cannot connect."""
+
+
+class InvalidAuth(HomeAssistantError):
+    """Error to indicate there is invalid auth."""

--- a/custom_components/ovo_energy_au/manifest.json
+++ b/custom_components/ovo_energy_au/manifest.json
@@ -3,6 +3,7 @@
   "name": "OVO Energy Australia",
   "documentation": "https://github.com/HallyAus/OVO_Aus_api",
   "issue_tracker": "https://github.com/HallyAus/OVO_Aus_api/issues",
+  "config_flow": true,
   "requirements": [
     "requests>=2.31.0",
     "python-dateutil>=2.8.2"
@@ -11,6 +12,6 @@
     "@HallyAus"
   ],
   "dependencies": [],
-  "version": "0.2.1",
+  "version": "0.2.2",
   "iot_class": "cloud_polling"
 }

--- a/custom_components/ovo_energy_au/strings.json
+++ b/custom_components/ovo_energy_au/strings.json
@@ -1,0 +1,23 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "OVO Energy Australia Setup",
+        "description": "Enter your OVO Energy Australia authentication tokens. Note: Tokens expire every 5 minutes and need to be refreshed. See documentation for token extraction instructions.",
+        "data": {
+          "access_token": "Access Token",
+          "id_token": "ID Token",
+          "account_id": "Account ID"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect to OVO Energy API",
+      "invalid_auth": "Invalid authentication tokens. Please check your access_token, id_token, and account_id.",
+      "unknown": "Unexpected error occurred"
+    },
+    "abort": {
+      "already_configured": "This OVO Energy account is already configured"
+    }
+  }
+}


### PR DESCRIPTION
FIXED: Sensors not appearing in Developer Tools

Changes:
- Add config_flow.py for UI-based integration setup (no more YAML required)
- Add strings.json for proper config flow UI labels
- Update manifest.json to v0.2.2 with config_flow: true
- Update README with new config flow documentation
- Update HACS_INSTALLATION.md with UI setup instructions

Users can now add the integration via Settings > Devices & Services