### PR TITLE
Fix config flow authentication issues

### DIFF
--- a/custom_components/ovo_energy_au/manifest.json
+++ b/custom_components/ovo_energy_au/manifest.json
@@ -12,6 +12,6 @@
     "@HallyAus"
   ],
   "dependencies": [],
-  "version": "0.2.6",
+  "version": "0.2.7",
   "iot_class": "cloud_polling"
 }


### PR DESCRIPTION
Fixes all three authentication methods:

1. OAuth JSON Paste:
   - Now auto-extracts account_id from JSON if present
   - Made account_id field optional if included in JSON
   - Fixes "invalid_json" error when account_id is in the pasted JSON

2. Manual Token Entry:
   - Automatically adds "Bearer " prefix to access tokens
   - Users no longer need to manually type "Bearer"
   - Just paste the raw token

3. Username & Password:
   - Improved error logging for debugging auth failures
   - Better error messages to distinguish connection vs auth errors
   - Added detailed debug logging for token extraction

All methods now consistently handle Bearer prefix and account_id. Bumped version to 0.2.7