### PR TITLE
Add product agreements API integration and plan information sensor (v…

### DIFF
--- a/custom_components/ovo_energy_au/__init__.py
+++ b/custom_components/ovo_energy_au/__init__.py
@@ -244,6 +244,15 @@ class OVOEnergyAUDataUpdateCoordinator(DataUpdateCoordinator):
             interval_data = await self.client.get_interval_data(self.account_id)
             processed_data = self._process_interval_data(interval_data)
 
+            # Fetch product agreements (plan information)
+            try:
+                product_info = await self.client.get_product_agreements(self.account_id)
+                processed_data["product_agreements"] = product_info
+                _LOGGER.debug("Successfully fetched product agreements")
+            except Exception as err:
+                _LOGGER.warning("Failed to fetch product agreements: %s", err)
+                processed_data["product_agreements"] = None
+
             # Fetch hourly data for the last 7 days
             # This ensures we:
             # 1. Work around the API issue where single-day queries return 0 results

--- a/custom_components/ovo_energy_au/const.py
+++ b/custom_components/ovo_energy_au/const.py
@@ -273,6 +273,45 @@ fragment UsageV2DataParts on UsageV2Data {
 }
 """
 
+GET_ACCOUNT_INFO_QUERY = """
+query GetAccountInfo($input: GetAccountInfoInput!) {
+  GetAccountInfo(input: $input) {
+    id
+    productAgreements {
+      id
+      fromDt
+      toDt
+      nmi
+      product {
+        code
+        displayName
+        standingChargeCentsPerDay
+        unitRatesCentsPerKWH {
+          standard
+          peak
+          shoulder
+          offPeak
+          evOffPeak
+          superOffPeak
+          feedInTariff
+          CL1
+          CL2
+          block
+          demand {
+            peakDemand
+            __typename
+          }
+          __typename
+        }
+        __typename
+      }
+      __typename
+    }
+    __typename
+  }
+}
+"""
+
 # Error messages
 ERROR_AUTH_FAILED = "Authentication failed. Please check your credentials."
 ERROR_CANNOT_CONNECT = "Cannot connect to OVO Energy API."

--- a/custom_components/ovo_energy_au/manifest.json
+++ b/custom_components/ovo_energy_au/manifest.json
@@ -12,6 +12,6 @@
     "@HallyAus"
   ],
   "dependencies": [],
-  "version": "2.6.0",
+  "version": "2.7.0",
   "iot_class": "cloud_polling"
 }


### PR DESCRIPTION
…2.7.0)

Features:
- Added GetAccountInfo GraphQL query to fetch product agreements from OVO API
- Created get_product_agreements() method in API client to retrieve plan details
- Updated config flow to use actual API plan data instead of analyzing charge types
- Added diagnostic sensor to display plan information in Home Assistant UI
- Plan sensor shows plan name as state with comprehensive attributes:
  - Plan name, product code, NMI, agreement dates
  - Standing charges (cents/day and $/day)
  - All unit rates in both cents/kWh and $/kWh
  - Peak, shoulder, off-peak, EV off-peak, super off-peak rates
  - Feed-in tariff rates

Implementation:
- Coordinator now fetches product agreements during data updates
- Auto-detection in config flow uses real API data (displayName, unitRatesCentsPerKWH)
- Converts cents to dollars for display (divide by 100)
- Maps API plan names to internal plan types (EV, Free 3, Basic, One)
- Diagnostic sensor with entity_category for proper UI placement

This provides users with accurate, real-time plan information directly from OVO's API.