### PR TITLE
Implement intelligent GetAccountInfo query with fallback strategy

### DIFF
--- a/custom_components/ovo_energy_au/const.py
+++ b/custom_components/ovo_energy_au/const.py
@@ -274,8 +274,8 @@ fragment UsageV2DataParts on UsageV2Data {
 """
 
 GET_ACCOUNT_INFO_QUERY = """
-query GetAccountInfo {
-  GetAccountInfo {
+query GetAccountInfo($input: GetAccountInfoInput!) {
+  GetAccountInfo(input: $input) {
     id
     productAgreements {
       id


### PR DESCRIPTION
Analysis of OVO Energy GraphQL API patterns:
- GetContactInfo uses email input extracted from ID token
- Applied same pattern to GetAccountInfo

Changes:
1. Extract email from ID token (same as GetContactInfo)
2. Try GetAccountInfo with email input first
3. If 400 error, fallback to accountId input
4. Comprehensive debug logging at each step

Query now uses input parameter:
```graphql
query GetAccountInfo($input: GetAccountInfoInput!) {
  GetAccountInfo(input: $input) { ... }
}
```

Variables tried:
- First attempt: {"input": {"email": "user@email.com"}}
- Fallback: {"input": {"accountId": "30264061"}}

This dual-approach strategy ensures we try both possible input methods and log detailed information for debugging which one works.

Added extensive logging:
- Email extraction
- Request payload details
- Response status codes
- GraphQL error messages
- Response data structure

This will definitively show us which input format the API expects.