### PR TITLE
Fix GetAccountInfo query using exact browser payload format

### DIFF
--- a/custom_components/ovo_energy_au/const.py
+++ b/custom_components/ovo_energy_au/const.py
@@ -281,23 +281,34 @@ query GetAccountInfo($input: GetAccountInfoInput!) {
       id
       fromDt
       toDt
+      fixedContractToDt
       nmi
       product {
         code
         displayName
+        paymentTiming
         standingChargeCentsPerDay
+        isSolarSponge
         unitRatesCentsPerKWH {
           standard
+          CL1
+          CL2
+          feedInTariff
+          isPremiumFeedInTariff
           peak
           shoulder
           offPeak
           evOffPeak
           superOffPeak
-          feedInTariff
-          CL1
-          CL2
-          block
+          block {
+            usageBlock1
+            usageBlock2
+            maxBlock1Threshold
+            __typename
+          }
           demand {
+            highSeasonDemand
+            lowSeasonDemand
             peakDemand
             __typename
           }


### PR DESCRIPTION
Root Cause Analysis:
The browser uses a different input format than what we were trying.

Browser's Working Payload:
- operationName: "GetProductAgreements" (not "GetAccountInfo")
- variables: {"input": {"id": "30264061", "system": "KALUZA"}}

Our Previous Attempts (ALL FAILED):
❌ No input parameters
❌ Email input (like GetContactInfo)
❌ accountId input

Correct Solution (from browser network traffic):
✅ id + system: "KALUZA" input

Changes Made:
1. Updated operation name to "GetProductAgreements"
2. Changed input to: {"id": account_id, "system": "KALUZA"}
3. Removed email extraction logic (not needed)
4. Removed fallback retry logic (not needed)
5. Updated GraphQL query with all browser fields:
   - fixedContractToDt
   - paymentTiming
   - isSolarSponge
   - isPremiumFeedInTariff
   - Enhanced block/demand structures

This matches the exact payload the browser sends to /graphql endpoint. The Plan Information sensor should now work correctly.