### PR TITLE
Fix query name to match operationName: GetProductAgreements

### DIFF
--- a/custom_components/ovo_energy_au/const.py
+++ b/custom_components/ovo_energy_au/const.py
@@ -274,7 +274,7 @@ fragment UsageV2DataParts on UsageV2Data {
 """
 
 GET_ACCOUNT_INFO_QUERY = """
-query GetAccountInfo($input: GetAccountInfoInput!) {
+query GetProductAgreements($input: GetAccountInfoInput!) {
   GetAccountInfo(input: $input) {
     id
     productAgreements {


### PR DESCRIPTION
Critical fix: The query declaration name must match the operationName.

Browser's exact format:
- operationName: 'GetProductAgreements'
- query: 'query GetProductAgreements(: ...) { ... }'

Previous (WRONG):
- operationName: 'GetProductAgreements'
- query: 'query GetAccountInfo(: ...) { ... }' ^^^ Mismatch!

This mismatch causes the GraphQL API to reject the query with 400 Bad Request.

Now both the operationName and query name are 'GetProductAgreements', exactly matching what the browser sends.