### PR TITLE
Fix options flow 500 error - remove undefined plan_name placeholder

### DIFF
--- a/custom_components/ovo_energy_au/strings.json
+++ b/custom_components/ovo_energy_au/strings.json
@@ -32,7 +32,7 @@
     "step": {
       "init": {
         "title": "Update Energy Plan Settings",
-        "description": "Modify your electricity plan and rates. Changes take effect immediately and update all cost calculations.\n\n**Current Plan:** {plan_name}\n\n**Tip:** If you've switched plans with OVO, update your selection here to ensure accurate cost tracking and savings calculations.",
+        "description": "Modify your electricity plan and rates. Changes take effect immediately and update all cost calculations.\n\n**Tip:** If you've switched plans with OVO, update your selection here to ensure accurate cost tracking and savings calculations.",
         "data": {
           "plan_type": "Energy Plan",
           "peak_rate": "Peak Rate ($/kWh)",

--- a/custom_components/ovo_energy_au/translations/en.json
+++ b/custom_components/ovo_energy_au/translations/en.json
@@ -32,7 +32,7 @@
     "step": {
       "init": {
         "title": "Update Energy Plan Settings",
-        "description": "Modify your electricity plan and rates. Changes take effect immediately and update all cost calculations.\n\n**Current Plan:** {plan_name}\n\n**Tip:** If you've switched plans with OVO, update your selection here to ensure accurate cost tracking and savings calculations.",
+        "description": "Modify your electricity plan and rates. Changes take effect immediately and update all cost calculations.\n\n**Tip:** If you've switched plans with OVO, update your selection here to ensure accurate cost tracking and savings calculations.",
         "data": {
           "plan_type": "Energy Plan",
           "peak_rate": "Peak Rate ($/kWh)",


### PR DESCRIPTION
Removed {plan_name} template variable from options flow description that was causing 500 Internal Server Error when clicking the settings cog.

The placeholder was not being provided by the options flow handler, causing the template rendering to fail.

Fixes: Config flow options dialog now loads correctly