### PR TITLE
Fix options flow initialization to use framework defaults

### DIFF
--- a/custom_components/ovo_energy_au/config_flow.py
+++ b/custom_components/ovo_energy_au/config_flow.py
@@ -245,15 +245,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @callback
     def async_get_options_flow(config_entry):
         """Get the options flow for this handler."""
-        return OptionsFlowHandler(config_entry)
+        return OptionsFlowHandler()
 
 
 class OptionsFlowHandler(config_entries.OptionsFlow):
     """Handle options flow for OVO Energy Australia."""
-
-    def __init__(self, config_entry):
-        """Initialize options flow."""
-        self.config_entry = config_entry
 
     async def async_step_init(self, user_input=None):
         """Manage the options."""


### PR DESCRIPTION
Removed custom __init__ from OptionsFlowHandler that was preventing proper initialization. The Home Assistant framework automatically sets self.config_entry and self.hass on OptionsFlow instances.

This fixes the 500 Internal Server Error when clicking the configure button on the integration.

Changes:
- Removed __init__ method from OptionsFlowHandler
- Updated async_get_options_flow to call OptionsFlowHandler() without args
- Framework now properly initializes config_entry and hass attributes