### PR TITLE
Fix per-day rate breakdown sensors by ensuring rate dicts exist

### DIFF
--- a/custom_components/ovo_energy_au/__init__.py
+++ b/custom_components/ovo_energy_au/__init__.py
@@ -514,6 +514,13 @@ class OVOEnergyAUDataUpdateCoordinator(DataUpdateCoordinator):
                                 "grid_rates_aud": {},
                             }
 
+                        # Ensure rate dictionaries exist even if solar_entries created the date
+                        if "grid_rates_kwh" not in daily_map[date_key]:
+                            daily_map[date_key]["grid_rates_kwh"] = {}
+                            daily_map[date_key]["grid_rates_aud"] = {}
+                            daily_map[date_key]["periodFrom"] = entry.get("periodFrom")
+                            daily_map[date_key]["periodTo"] = entry.get("periodTo")
+
                         charge_type = entry.get("charge", {}).get("type", "DEBIT")
                         consumption = entry.get("consumption", 0)
                         charge_value = entry.get("charge", {}).get("value", 0)


### PR DESCRIPTION
Root cause: solar_entries loop creates daily_map[date_key] without grid_rates_kwh/grid_rates_aud, then export_entries loop skips initialization because date_key already exists. This caused KeyError when trying to accumulate rates, caught silently by try/except.

Fix: Add initialization check after the existing daily_map creation to ensure grid_rates_kwh and grid_rates_aud dictionaries exist even if solar_entries created the date first. Also ensures periodFrom and periodTo timestamps are set.

Expected result: Sensors will now show actual rate breakdown values
(e.g., EV_OFFPEAK: 20.88 kWh) instead of 0.00 for all sensors.

Debug logging still present - will be removed after verification.