### PR TITLE
Rebuild dashboards using confirmed entity IDs from user's HA instance

### DIFF
--- a/dashboard_example.yaml
+++ b/dashboard_example.yaml
@@ -4,18 +4,6 @@
 # - mushroom: https://github.com/piitaya/lovelace-mushroom
 # - apexcharts-card: https://github.com/RomRider/apexcharts-card
 #
-# IMPORTANT - Entity ID Note:
-# This integration uses has_entity_name=True with device grouping.
-# Your entity IDs will be in the format:
-#   sensor.ovo_energy_au_{category}_{sensor_name}
-#
-# For example:
-#   sensor.ovo_energy_au_this_month_solar_consumption
-#   sensor.ovo_energy_au_yesterday_grid_charge
-#
-# If your entity IDs differ, go to Settings → Devices → OVO Energy AU
-# to find the exact entity IDs for your installation.
-#
 # To use this dashboard:
 # 1. Go to Settings → Dashboards → Add Dashboard
 # 2. Choose "New dashboard from scratch"
@@ -31,20 +19,7 @@ views:
     path: overview
     icon: mdi:view-dashboard
     cards:
-      # Plan & Account Info
-      - type: custom:mushroom-template-card
-        primary: >
-          {{ states('sensor.ovo_energy_au_plan_information') }}
-        secondary: >
-          Standing charge: ${{ state_attr('sensor.ovo_energy_au_plan_information', 'standing_charge_aud_per_day') }}/day
-        icon: mdi:file-document-outline
-        icon_color: deep-purple
-        entity: sensor.ovo_energy_au_plan_information
-        tap_action:
-          action: more-info
-        layout: horizontal
-
-      # This Month Summary Row
+      # This Month kWh Summary
       - type: horizontal-stack
         cards:
           - type: custom:mushroom-template-card
@@ -118,40 +93,23 @@ views:
               action: more-info
             layout: vertical
 
-      # Self-Sufficiency & Projection
-      - type: horizontal-stack
-        cards:
-          - type: gauge
-            entity: sensor.ovo_energy_au_solar_insights_self_sufficiency_score
-            name: Self-Sufficiency
-            min: 0
-            max: 100
-            needle: true
-            severity:
-              green: 60
-              yellow: 30
-              red: 0
-          - type: custom:mushroom-template-card
-            primary: Monthly Projection
-            secondary: >
-              Projected: ${{ states('sensor.ovo_energy_au_monthly_forecast_projected_monthly_cost') }}
+      # Self-Sufficiency Gauge
+      - type: gauge
+        entity: sensor.ovo_energy_au_solar_insights_self_sufficiency_score
+        name: Solar Self-Sufficiency
+        min: 0
+        max: 100
+        needle: true
+        severity:
+          green: 60
+          yellow: 30
+          red: 0
 
-              Remaining: ${{ states('sensor.ovo_energy_au_monthly_forecast_projected_remaining_cost') }}
-
-              Daily Avg: ${{ states('sensor.ovo_energy_au_monthly_forecast_daily_average_cost') }}
-            icon: mdi:crystal-ball
-            icon_color: deep-purple
-            entity: sensor.ovo_energy_au_monthly_forecast_projected_monthly_cost
-            tap_action:
-              action: more-info
-            multiline_secondary: true
-            layout: horizontal
-
-      # Daily Solar vs Grid Chart (This Month)
+      # Daily Solar vs Grid vs Export Chart (This Month)
       - type: custom:apexcharts-card
         header:
           show: true
-          title: Daily Solar vs Grid (This Month)
+          title: Daily Usage (This Month)
           show_states: true
           colorize_states: true
         graph_span: 1month
@@ -252,9 +210,6 @@ views:
           tooltip:
             x:
               format: dd MMM yyyy
-            y:
-              formatter: |
-                EVAL:function(value) { return "$" + value.toFixed(2); }
 
       # Yesterday Summary
       - type: custom:mushroom-title-card
@@ -480,7 +435,7 @@ views:
             x:
               format: dd MMM yyyy
 
-      # Solar Charge Chart
+      # Solar Feed-in Credit Chart
       - type: custom:apexcharts-card
         header:
           show: true
@@ -516,160 +471,40 @@ views:
           tooltip:
             x:
               format: dd MMM yyyy
-            y:
-              formatter: |
-                EVAL:function(value) { return "$" + value.toFixed(2); }
 
-      # Period Comparison
+      # This Year Totals
       - type: custom:mushroom-title-card
-        title: Period Comparison
-
-      - type: entities
-        entities:
-          - type: section
-            label: Last 7 Days
-          - entity: sensor.ovo_energy_au_last_week_solar_consumption
-            name: Solar
-          - entity: sensor.ovo_energy_au_last_week_grid_consumption
-            name: Grid
-          - entity: sensor.ovo_energy_au_last_week_solar_feed_in_credit
-            name: Solar Credit
-          - entity: sensor.ovo_energy_au_last_week_grid_charge
-            name: Grid Cost
-          - type: section
-            label: Last Month
-          - entity: sensor.ovo_energy_au_last_month_solar_consumption
-            name: Solar
-          - entity: sensor.ovo_energy_au_last_month_grid_consumption
-            name: Grid
-          - entity: sensor.ovo_energy_au_last_month_solar_feed_in_credit
-            name: Solar Credit
-          - entity: sensor.ovo_energy_au_last_month_grid_charge
-            name: Grid Cost
-          - type: section
-            label: Month to Date
-          - entity: sensor.ovo_energy_au_month_to_date_solar_consumption
-            name: Solar
-          - entity: sensor.ovo_energy_au_month_to_date_grid_consumption
-            name: Grid
-          - entity: sensor.ovo_energy_au_month_to_date_solar_feed_in_credit
-            name: Solar Credit
-          - entity: sensor.ovo_energy_au_month_to_date_grid_charge
-            name: Grid Cost
-          - type: section
-            label: This Year
-          - entity: sensor.ovo_energy_au_this_year_solar_consumption
-            name: Solar
-          - entity: sensor.ovo_energy_au_this_year_grid_consumption
-            name: Grid
-          - entity: sensor.ovo_energy_au_this_year_grid_charge
-            name: Grid Cost
-
-  # ============================================================
-  # VIEW 3: YESTERDAY DETAIL & RATE BREAKDOWN
-  # ============================================================
-  - title: Yesterday
-    path: yesterday
-    icon: mdi:calendar-today
-    cards:
-      # Yesterday Usage
-      - type: custom:mushroom-title-card
-        title: Yesterday's Usage
-        subtitle: Detailed daily breakdown
+        title: This Year
 
       - type: horizontal-stack
         cards:
           - type: custom:mushroom-template-card
             primary: Solar
             secondary: >
-              {{ states('sensor.ovo_energy_au_yesterday_solar_consumption') }} kWh
-
-              Credit: ${{ states('sensor.ovo_energy_au_yesterday_solar_feed_in_credit') }}
+              {{ states('sensor.ovo_energy_au_this_year_solar_consumption') }} kWh
             icon: mdi:solar-power
             icon_color: amber
-            entity: sensor.ovo_energy_au_yesterday_solar_consumption
-            multiline_secondary: true
+            entity: sensor.ovo_energy_au_this_year_solar_consumption
             layout: vertical
-            tap_action:
-              action: more-info
           - type: custom:mushroom-template-card
             primary: Grid
             secondary: >
-              {{ states('sensor.ovo_energy_au_yesterday_grid_consumption') }} kWh
-
-              Cost: ${{ states('sensor.ovo_energy_au_yesterday_grid_charge') }}
+              {{ states('sensor.ovo_energy_au_this_year_grid_consumption') }} kWh
             icon: mdi:transmission-tower
             icon_color: red
-            entity: sensor.ovo_energy_au_yesterday_grid_consumption
-            multiline_secondary: true
+            entity: sensor.ovo_energy_au_this_year_grid_consumption
             layout: vertical
-            tap_action:
-              action: more-info
           - type: custom:mushroom-template-card
-            primary: Exported
+            primary: Grid Cost
             secondary: >
-              {{ states('sensor.ovo_energy_au_yesterday_return_to_grid') }} kWh
-
-              Credit: ${{ states('sensor.ovo_energy_au_yesterday_return_to_grid_charge') }}
-            icon: mdi:transmission-tower-export
-            icon_color: blue
-            entity: sensor.ovo_energy_au_yesterday_return_to_grid
-            multiline_secondary: true
+              ${{ states('sensor.ovo_energy_au_this_year_grid_charge') }}
+            icon: mdi:currency-usd
+            icon_color: deep-orange
+            entity: sensor.ovo_energy_au_this_year_grid_charge
             layout: vertical
-            tap_action:
-              action: more-info
-
-      # Yesterday Rate Breakdown (from API rates)
-      - type: custom:mushroom-title-card
-        title: Yesterday Rate Breakdown
-
-      - type: custom:mushroom-template-card
-        primary: Total Consumption by Rate
-        secondary: >
-          {{ states('sensor.ovo_energy_au_rate_breakdown_yesterday') }} kWh total
-        icon: mdi:cash-multiple
-        icon_color: deep-purple
-        entity: sensor.ovo_energy_au_rate_breakdown_yesterday
-        tap_action:
-          action: more-info
-
-      - type: entities
-        title: Yesterday - Rate Type Detail
-        entities:
-          - entity: sensor.ovo_energy_au_rate_breakdown_yesterday_ev_off_peak_consumption
-            name: EV Off-Peak Usage
-            icon: mdi:ev-station
-          - entity: sensor.ovo_energy_au_rate_breakdown_yesterday_ev_off_peak_cost
-            name: EV Off-Peak Cost
-            icon: mdi:currency-usd
-          - entity: sensor.ovo_energy_au_rate_breakdown_yesterday_free_period_consumption
-            name: Free Period Usage
-            icon: mdi:gift
-          - entity: sensor.ovo_energy_au_rate_breakdown_yesterday_free_period_savings
-            name: Free Period Savings
-            icon: mdi:piggy-bank
-          - entity: sensor.ovo_energy_au_rate_breakdown_yesterday_other_rates_consumption
-            name: Other Rates Usage
-            icon: mdi:chart-bar
-          - entity: sensor.ovo_energy_au_rate_breakdown_yesterday_other_rates_cost
-            name: Other Rates Cost
-            icon: mdi:currency-usd
-
-      # 3-Day Snapshot Note
-      - type: markdown
-        content: |
-          ### 3-Day Snapshot
-          The integration also creates detailed sensors for the last 3 days
-          with per-rate-type breakdowns (Peak, Shoulder, Off-Peak, EV, Free).
-
-          To find these entities, go to:
-          **Settings** → **Devices** → **OVO Energy AU - 3 Day Snapshot**
-
-          These sensors have dynamic entity IDs based on your installation date,
-          so they need to be added manually to your dashboard.
 
   # ============================================================
-  # VIEW 4: ANALYTICS
+  # VIEW 3: ANALYTICS
   # ============================================================
   - title: Analytics
     path: analytics
@@ -746,82 +581,6 @@ views:
             multiline_secondary: true
             layout: vertical
 
-      # Cost Analysis
-      - type: custom:mushroom-title-card
-        title: Cost Analysis
-        subtitle: Effective rates per kWh
-
-      - type: horizontal-stack
-        cards:
-          - type: custom:mushroom-template-card
-            primary: Overall
-            secondary: >
-              ${{ states('sensor.ovo_energy_au_cost_analysis_overall_cost_per_kwh') }}/kWh
-            icon: mdi:chart-donut
-            icon_color: deep-purple
-            entity: sensor.ovo_energy_au_cost_analysis_overall_cost_per_kwh
-            layout: vertical
-          - type: custom:mushroom-template-card
-            primary: Grid Rate
-            secondary: >
-              ${{ states('sensor.ovo_energy_au_cost_analysis_grid_cost_per_kwh') }}/kWh
-            icon: mdi:transmission-tower
-            icon_color: red
-            entity: sensor.ovo_energy_au_cost_analysis_grid_cost_per_kwh
-            layout: vertical
-          - type: custom:mushroom-template-card
-            primary: Solar Rate
-            secondary: >
-              ${{ states('sensor.ovo_energy_au_cost_analysis_solar_cost_per_kwh') }}/kWh
-            icon: mdi:solar-power
-            icon_color: amber
-            entity: sensor.ovo_energy_au_cost_analysis_solar_cost_per_kwh
-            layout: vertical
-
-      # Peak Usage
-      - type: custom:mushroom-template-card
-        primary: Peak 4-Hour Window
-        secondary: >
-          {{ state_attr('sensor.ovo_energy_au_peak_usage_peak_4_hour_consumption', 'start_time') }}
-          → {{ state_attr('sensor.ovo_energy_au_peak_usage_peak_4_hour_consumption', 'end_time') }}
-          ({{ states('sensor.ovo_energy_au_peak_usage_peak_4_hour_consumption') }} kWh)
-        icon: mdi:chart-bell-curve
-        icon_color: orange
-        entity: sensor.ovo_energy_au_peak_usage_peak_4_hour_consumption
-        tap_action:
-          action: more-info
-
-      # Monthly Cost Projection
-      - type: custom:mushroom-title-card
-        title: Monthly Cost Projection
-
-      - type: horizontal-stack
-        cards:
-          - type: custom:mushroom-template-card
-            primary: Projected Total
-            secondary: >
-              ${{ states('sensor.ovo_energy_au_monthly_forecast_projected_monthly_cost') }}
-            icon: mdi:crystal-ball
-            icon_color: deep-purple
-            entity: sensor.ovo_energy_au_monthly_forecast_projected_monthly_cost
-            layout: vertical
-          - type: custom:mushroom-template-card
-            primary: Remaining
-            secondary: >
-              ${{ states('sensor.ovo_energy_au_monthly_forecast_projected_remaining_cost') }}
-            icon: mdi:calendar-clock
-            icon_color: orange
-            entity: sensor.ovo_energy_au_monthly_forecast_projected_remaining_cost
-            layout: vertical
-          - type: custom:mushroom-template-card
-            primary: Daily Avg
-            secondary: >
-              ${{ states('sensor.ovo_energy_au_monthly_forecast_daily_average_cost') }}
-            icon: mdi:chart-line
-            icon_color: teal
-            entity: sensor.ovo_energy_au_monthly_forecast_daily_average_cost
-            layout: vertical
-
       # High Usage Days
       - type: custom:mushroom-title-card
         title: High Usage Days
@@ -837,8 +596,26 @@ views:
         tap_action:
           action: more-info
 
+      # Yesterday Rate Breakdown
+      - type: custom:mushroom-title-card
+        title: Yesterday Rate Breakdown
+        subtitle: Consumption by rate type
+
+      - type: entities
+        title: Yesterday - Rate Type Detail
+        entities:
+          - entity: sensor.ovo_energy_au_rate_breakdown_yesterday_ev_off_peak_consumption
+            name: EV Off-Peak Usage
+            icon: mdi:ev-station
+          - entity: sensor.ovo_energy_au_rate_breakdown_yesterday_ev_off_peak_cost
+            name: EV Off-Peak Cost
+            icon: mdi:currency-usd
+          - entity: sensor.ovo_energy_au_rate_breakdown_yesterday_free_period_consumption
+            name: Free Period Usage
+            icon: mdi:gift
+
   # ============================================================
-  # VIEW 5: SOLAR & EXPORT
+  # VIEW 4: SOLAR & EXPORT
   # ============================================================
   - title: Solar & Export
     path: solar
@@ -1005,124 +782,6 @@ views:
           tooltip:
             x:
               format: dd MMM yyyy
-            y:
-              formatter: |
-                EVAL:function(value) { return "$" + value.toFixed(2); }
           legend:
             show: true
             position: top
-
-  # ============================================================
-  # VIEW 6: RATE BREAKDOWN
-  # ============================================================
-  - title: Rates
-    path: rates
-    icon: mdi:chart-bar
-    cards:
-      # Rate Breakdown Summary Sensors
-      - type: custom:mushroom-title-card
-        title: Rate Breakdown
-        subtitle: Consumption by rate type with counterfactual analysis
-
-      # Yesterday Rate Breakdown
-      - type: custom:mushroom-template-card
-        primary: Yesterday - Rate Breakdown
-        secondary: >
-          {{ states('sensor.ovo_energy_au_rate_breakdown_yesterday') }} kWh total
-        icon: mdi:cash-multiple
-        icon_color: deep-purple
-        entity: sensor.ovo_energy_au_rate_breakdown_yesterday
-        tap_action:
-          action: more-info
-
-      - type: entities
-        title: Yesterday Rates
-        entities:
-          - entity: sensor.ovo_energy_au_rate_breakdown_yesterday_ev_off_peak_consumption
-            name: EV Off-Peak
-            icon: mdi:ev-station
-          - entity: sensor.ovo_energy_au_rate_breakdown_yesterday_ev_off_peak_cost
-            name: EV Off-Peak Cost
-            icon: mdi:currency-usd
-          - entity: sensor.ovo_energy_au_rate_breakdown_yesterday_free_period_consumption
-            name: Free Period
-            icon: mdi:gift
-          - entity: sensor.ovo_energy_au_rate_breakdown_yesterday_free_period_savings
-            name: Free Period Savings
-            icon: mdi:piggy-bank
-          - entity: sensor.ovo_energy_au_rate_breakdown_yesterday_other_rates_consumption
-            name: Other Rates
-            icon: mdi:chart-bar
-          - entity: sensor.ovo_energy_au_rate_breakdown_yesterday_other_rates_cost
-            name: Other Rates Cost
-            icon: mdi:currency-usd
-
-      # This Month Rate Breakdown
-      - type: custom:mushroom-template-card
-        primary: This Month - Rate Breakdown
-        secondary: >
-          {{ states('sensor.ovo_energy_au_rate_breakdown_this_month') }} kWh total
-        icon: mdi:cash-multiple
-        icon_color: indigo
-        entity: sensor.ovo_energy_au_rate_breakdown_this_month
-        tap_action:
-          action: more-info
-
-      - type: entities
-        title: This Month Rates
-        entities:
-          - entity: sensor.ovo_energy_au_rate_breakdown_this_month_ev_off_peak_consumption
-            name: EV Off-Peak
-            icon: mdi:ev-station
-          - entity: sensor.ovo_energy_au_rate_breakdown_this_month_ev_off_peak_cost
-            name: EV Off-Peak Cost
-            icon: mdi:currency-usd
-          - entity: sensor.ovo_energy_au_rate_breakdown_this_month_free_period_consumption
-            name: Free Period
-            icon: mdi:gift
-          - entity: sensor.ovo_energy_au_rate_breakdown_this_month_free_period_savings
-            name: Free Period Savings
-            icon: mdi:piggy-bank
-          - entity: sensor.ovo_energy_au_rate_breakdown_this_month_other_rates_consumption
-            name: Other Rates
-            icon: mdi:chart-bar
-          - entity: sensor.ovo_energy_au_rate_breakdown_this_month_other_rates_cost
-            name: Other Rates Cost
-            icon: mdi:currency-usd
-
-      # This Year Rate Breakdown
-      - type: custom:mushroom-template-card
-        primary: This Year - Rate Breakdown
-        secondary: >
-          {{ states('sensor.ovo_energy_au_rate_breakdown_this_year') }} kWh total
-        icon: mdi:cash-multiple
-        icon_color: teal
-        entity: sensor.ovo_energy_au_rate_breakdown_this_year
-        tap_action:
-          action: more-info
-
-      # All Time Rate Breakdown
-      - type: custom:mushroom-template-card
-        primary: All Time - Rate Breakdown
-        secondary: >
-          {{ states('sensor.ovo_energy_au_rate_breakdown_all_time') }} kWh total
-        icon: mdi:cash-multiple
-        icon_color: brown
-        entity: sensor.ovo_energy_au_rate_breakdown_all_time
-        tap_action:
-          action: more-info
-
-      # Plan Rate Info
-      - type: custom:mushroom-title-card
-        title: Plan Rates
-
-      - type: markdown
-        content: |
-          | Rate Type | c/kWh | $/kWh |
-          |-----------|-------|-------|
-          | Peak | {{ state_attr('sensor.ovo_energy_au_plan_information', 'peak_cents_kwh') }}c | ${{ state_attr('sensor.ovo_energy_au_plan_information', 'peak_aud_kwh') }} |
-          | Shoulder | {{ state_attr('sensor.ovo_energy_au_plan_information', 'shoulder_cents_kwh') }}c | ${{ state_attr('sensor.ovo_energy_au_plan_information', 'shoulder_aud_kwh') }} |
-          | Off-Peak | {{ state_attr('sensor.ovo_energy_au_plan_information', 'off_peak_cents_kwh') }}c | ${{ state_attr('sensor.ovo_energy_au_plan_information', 'off_peak_aud_kwh') }} |
-          | EV Off-Peak | {{ state_attr('sensor.ovo_energy_au_plan_information', 'ev_off_peak_cents_kwh') }}c | ${{ state_attr('sensor.ovo_energy_au_plan_information', 'ev_off_peak_aud_kwh') }} |
-          | Feed-in Tariff | {{ state_attr('sensor.ovo_energy_au_plan_information', 'feed_in_tariff_cents_kwh') }}c | ${{ state_attr('sensor.ovo_energy_au_plan_information', 'feed_in_tariff_aud_kwh') }} |
-          | Standing Charge | {{ state_attr('sensor.ovo_energy_au_plan_information', 'standing_charge_cents_per_day') }}c/day | ${{ state_attr('sensor.ovo_energy_au_plan_information', 'standing_charge_aud_per_day') }}/day |


### PR DESCRIPTION
Matched all entity IDs to actual devices/entities confirmed by user:
- OVO Energy AU - This Month (6 sensors)
- OVO Energy AU - Yesterday (6 sensors)
- OVO Energy AU - This Year (3 sensors)
- OVO Energy AU - Rate Breakdown - Yesterday (3 sensors)
- OVO Energy AU - Solar Export (4 sensors)
- OVO Energy AU - Solar Insights (1 sensor)
- OVO Energy AU - Week Comparison (6 sensors)
- OVO Energy AU - Weekday vs Weekend (4 sensors)
- OVO Energy AU - Usage Rankings (1 sensor)
- OVO Energy AU - Usage Patterns (1 sensor)

Removed references to entities not present in user's installation:
- Plan Information, Monthly Forecast, Cost Analysis, Peak Usage
- Last Week, Last Month, Month to Date period sensors

Dashboard now has 4 views: Overview, Monthly, Analytics, Solar & Export

https://claude.ai/code/session_0148MwuvrLyDW1ofq3dwRiMK