### PR TITLE
v4.1.1: Fix crashing health sensor, duplicate day sensors, docs refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the OVO Energy Australia Home Assistant integration will 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.1] - 2026-04-22
+
+### Bug Fixes
+- **#66 / #65** - Fixed `AttributeError: 'OVOEnergyAUDataUpdateCoordinator' object has no attribute 'last_update_success_time'` spamming logs every coordinator refresh. Coordinator now inherits from `TimestampDataUpdateCoordinator`, which provides `last_update_success_time` as a proper datetime. Integration Health sensor now populates correctly.
+- **#64** - Fixed duplicate per-day sensors with `_2`, `_3`, `_4` suffixes. Dynamic day sensors (`OVODaySensor`, `OVODayRateSensor`) now include the day number in their display name so Home Assistant's entity-id slugification produces unique IDs. Affected sensors: `day_N_solar_consumption`, `day_N_grid_rate_*_consumption`, `day_N_grid_rate_*_charge`, etc.
+- **#54** - Fixed `DASHBOARD_GUIDE.md` sensor references missing the `ovo_energy_au_` entity prefix (e.g., `sensor.daily_solar_consumption` → `sensor.ovo_energy_au_daily_solar_consumption`). All daily/monthly/yearly/hourly references corrected.
+- **#58** - Bumped manifest version to 4.1.1 so HACS displays the semantic version. Note: a matching `v4.1.1` GitHub release/tag must be created for HACS to resolve the version correctly.
+
+### Known Issues
+- **#63** (feature request) - Manual peak/off-peak window config for the `OTHER` charge bucket on the 3 Free TOU plan is planned for a future release.
+
 ## [4.1.0] - 2026-03-21
 
 ### New Sensors

--- a/custom_components/ovo_energy_au/coordinator.py
+++ b/custom_components/ovo_energy_au/coordinator.py
@@ -7,7 +7,10 @@ from datetime import timedelta
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.helpers.update_coordinator import (
+    TimestampDataUpdateCoordinator,
+    UpdateFailed,
+)
 from homeassistant.util import dt as dt_util
 
 from .analytics.hourly import process_hourly_data
@@ -25,7 +28,7 @@ from .models import PlanConfig
 _LOGGER = logging.getLogger(__name__)
 
 
-class OVOEnergyAUDataUpdateCoordinator(DataUpdateCoordinator):
+class OVOEnergyAUDataUpdateCoordinator(TimestampDataUpdateCoordinator):
     """Fetch and process data from OVO Energy Australia API."""
 
     def __init__(

--- a/custom_components/ovo_energy_au/manifest.json
+++ b/custom_components/ovo_energy_au/manifest.json
@@ -12,5 +12,5 @@
   "requirements": [
     "PyJWT>=2.8.0"
   ],
-  "version": "4.1.0"
+  "version": "4.1.1"
 }

--- a/custom_components/ovo_energy_au/sensor.py
+++ b/custom_components/ovo_energy_au/sensor.py
@@ -135,7 +135,9 @@ def _add_rate_sensors(sensors: list, coordinator, period: str, label: str) -> No
 
 def _add_dynamic_day_sensors(sensors: list, coordinator) -> None:
     """Add per-day sensors for the last 7 days."""
-    # Always create 7 day sensors regardless of initial data availability
+    # Always create 7 day sensors regardless of initial data availability.
+    # Each sensor name MUST include the day number so HA's has_entity_name=True
+    # slugification produces distinct entity_ids (avoids _2/_3 collision suffixes).
     for idx in range(7):
         day_num = idx + 1
         for key, name, unit, dc, sc, icon in [
@@ -149,21 +151,23 @@ def _add_dynamic_day_sensors(sensors: list, coordinator) -> None:
              SensorDeviceClass.MONETARY, SensorStateClass.TOTAL, "mdi:currency-usd"),
         ]:
             sensors.append(OVODaySensor(
-                coordinator, f"day_{day_num}_{key}", name, unit, dc, sc, icon, idx, key
+                coordinator, f"day_{day_num}_{key}", f"Day {day_num} {name}",
+                unit, dc, sc, icon, idx, key,
             ))
 
         # Per-rate breakdown for this day
         for rate_type in RATE_TYPES:
+            rate_label = rate_type.replace("_", " ").title()
             sensors.append(OVODayRateSensor(
                 coordinator, f"day_{day_num}_grid_rate_{rate_type.lower()}_consumption",
-                f"{rate_type.replace('_', ' ').title()} Consumption",
+                f"Day {day_num} {rate_label} Consumption",
                 UnitOfEnergy.KILO_WATT_HOUR, SensorDeviceClass.ENERGY, SensorStateClass.TOTAL,
                 RATE_TYPE_ICONS.get(rate_type, "mdi:flash"), idx, rate_type, "grid_rates_kwh",
             ))
             is_free = rate_type == "FREE_3"
             sensors.append(OVODayRateSensor(
                 coordinator, f"day_{day_num}_grid_rate_{rate_type.lower()}_charge",
-                f"{rate_type.replace('_', ' ').title()} {'Savings' if is_free else 'Cost'}",
+                f"Day {day_num} {rate_label} {'Savings' if is_free else 'Cost'}",
                 "AUD", SensorDeviceClass.MONETARY, SensorStateClass.TOTAL,
                 "mdi:piggy-bank" if is_free else "mdi:currency-usd",
                 idx, rate_type, "grid_rates_aud",

--- a/docs/guides/DASHBOARD_GUIDE.md
+++ b/docs/guides/DASHBOARD_GUIDE.md
@@ -5,20 +5,20 @@ This integration provides comprehensive energy monitoring with daily breakdown d
 ## Available Sensors
 
 ### Daily Sensors (Today's Usage)
-- `sensor.daily_solar_consumption` - Solar energy consumed today (kWh)
-- `sensor.daily_grid_consumption` - Grid energy consumed today (kWh)
-- `sensor.daily_return_to_grid` - Energy exported to grid today (kWh)
-- `sensor.daily_solar_charge` - Cost of solar today ($)
-- `sensor.daily_grid_charge` - Cost of grid today ($)
-- `sensor.daily_return_to_grid_charge` - Credit from exports today ($)
+- `sensor.ovo_energy_au_daily_solar_consumption` - Solar energy consumed today (kWh)
+- `sensor.ovo_energy_au_daily_grid_consumption` - Grid energy consumed today (kWh)
+- `sensor.ovo_energy_au_daily_return_to_grid` - Energy exported to grid today (kWh)
+- `sensor.ovo_energy_au_daily_solar_charge` - Cost of solar today ($)
+- `sensor.ovo_energy_au_daily_grid_charge` - Cost of grid today ($)
+- `sensor.ovo_energy_au_daily_return_to_grid_charge` - Credit from exports today ($)
 
 ### Monthly Sensors (Current Month)
-- `sensor.monthly_solar_consumption` - Total solar this month (kWh)
-- `sensor.monthly_grid_consumption` - Total grid this month (kWh)
-- `sensor.monthly_return_to_grid` - Total exports this month (kWh)
-- `sensor.monthly_solar_charge` - Total solar cost this month ($)
-- `sensor.monthly_grid_charge` - Total grid cost this month ($)
-- `sensor.monthly_return_to_grid_charge` - Total export credit this month ($)
+- `sensor.ovo_energy_au_monthly_solar_consumption` - Total solar this month (kWh)
+- `sensor.ovo_energy_au_monthly_grid_consumption` - Total grid this month (kWh)
+- `sensor.ovo_energy_au_monthly_return_to_grid` - Total exports this month (kWh)
+- `sensor.ovo_energy_au_monthly_solar_charge` - Total solar cost this month ($)
+- `sensor.ovo_energy_au_monthly_grid_charge` - Total grid cost this month ($)
+- `sensor.ovo_energy_au_monthly_return_to_grid_charge` - Total export credit this month ($)
 
 **Monthly sensors include daily breakdown attributes:**
 - `daily_breakdown` - Array of daily entries with date, consumption, and charge
@@ -28,14 +28,14 @@ This integration provides comprehensive energy monitoring with daily breakdown d
 - `daily_charge_average` - Average cost per day
 
 ### Yearly Sensors
-- `sensor.yearly_solar_consumption` - Total solar this year (kWh)
-- `sensor.yearly_grid_consumption` - Total grid this year (kWh)
-- `sensor.yearly_grid_charge` - Total grid cost this year ($)
+- `sensor.ovo_energy_au_yearly_solar_consumption` - Total solar this year (kWh)
+- `sensor.ovo_energy_au_yearly_grid_consumption` - Total grid this year (kWh)
+- `sensor.ovo_energy_au_yearly_grid_charge` - Total grid cost this year ($)
 
 ### Hourly Sensors (Last 7 Days)
-- `sensor.hourly_solar_consumption` - Total solar over 7 days (kWh)
-- `sensor.hourly_grid_consumption` - Total grid over 7 days (kWh)
-- `sensor.hourly_return_to_grid` - Total exports over 7 days (kWh)
+- `sensor.ovo_energy_au_hourly_solar_consumption` - Total solar over 7 days (kWh)
+- `sensor.ovo_energy_au_hourly_grid_consumption` - Total grid over 7 days (kWh)
+- `sensor.ovo_energy_au_hourly_return_to_grid` - Total exports over 7 days (kWh)
 
 **Hourly sensors include entry arrays for detailed graphing:**
 - `entries` - Array of hourly data points with timestamps
@@ -112,7 +112,7 @@ type: custom:apexcharts-card
 header:
   title: Daily Solar Consumption
 series:
-  - entity: sensor.monthly_solar_consumption
+  - entity: sensor.ovo_energy_au_monthly_solar_consumption
     name: Solar kWh
     type: column
     color: orange
@@ -130,7 +130,7 @@ template:
       - name: "Today Solar Charge"
         state: >
           {% set today = now().strftime('%Y-%m-%d') %}
-          {% set breakdown = state_attr('sensor.monthly_solar_charge', 'daily_breakdown') %}
+          {% set breakdown = state_attr('sensor.ovo_energy_au_monthly_solar_charge', 'daily_breakdown') %}
           {% if breakdown %}
             {% set today_data = breakdown | selectattr('date', 'eq', today) | list %}
             {% if today_data %}
@@ -149,7 +149,7 @@ template:
 type: markdown
 content: |
   ## Daily Solar Breakdown
-  {% set breakdown = state_attr('sensor.monthly_solar_consumption', 'daily_breakdown') %}
+  {% set breakdown = state_attr('sensor.ovo_energy_au_monthly_solar_consumption', 'daily_breakdown') %}
   {% if breakdown %}
   | Date | kWh | Cost |
   |------|-----|------|

--- a/info.md
+++ b/info.md
@@ -1,7 +1,7 @@
 # OVO Energy Australia for Home Assistant
 
 [![HACS Custom](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/hacs/integration)
-[![Version](https://img.shields.io/badge/version-4.1.0-blue.svg)](https://github.com/HallyAus/OVO_Aus_api/releases)
+[![Version](https://img.shields.io/badge/version-4.1.1-blue.svg)](https://github.com/HallyAus/OVO_Aus_api/releases)
 [![CI](https://github.com/HallyAus/OVO_Aus_api/actions/workflows/ci.yml/badge.svg)](https://github.com/HallyAus/OVO_Aus_api/actions/workflows/ci.yml)
 
 Track solar generation, grid consumption, costs, EV charging, and plan savings in Home Assistant.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,10 @@ class _DataUpdateCoordinator:
     def __init__(self, *args, **kwargs):
         pass
 
+class _TimestampDataUpdateCoordinator(_DataUpdateCoordinator):
+    """Stub for TimestampDataUpdateCoordinator (adds last_update_success_time)."""
+    last_update_success_time = None
+
 class _UpdateFailed(Exception):
     """Stub for UpdateFailed."""
     pass
@@ -39,6 +43,7 @@ class _UpdateFailed(Exception):
 coordinator_mod = types.ModuleType("homeassistant.helpers.update_coordinator")
 coordinator_mod.CoordinatorEntity = _CoordinatorEntity
 coordinator_mod.DataUpdateCoordinator = _DataUpdateCoordinator
+coordinator_mod.TimestampDataUpdateCoordinator = _TimestampDataUpdateCoordinator
 coordinator_mod.UpdateFailed = _UpdateFailed
 sys.modules.setdefault("homeassistant.helpers.update_coordinator", coordinator_mod)
 


### PR DESCRIPTION
## Summary

Releases **v4.1.1** — a bug-fix release that resolves five open issues reported against v4.1.0.

| Issue | Fix |
|---|---|
| #66 / #65 | `OVOEnergyAUDataUpdateCoordinator` now inherits from `TimestampDataUpdateCoordinator`, so `self.coordinator.last_update_success_time` exists. Stops the repeating `AttributeError` in `OVOHealthSensor.extra_state_attributes` on every coordinator refresh. |
| #64 | Dynamic per-day sensors (`OVODaySensor`, `OVODayRateSensor`) now prepend `Day {n}` to their display names. With `has_entity_name=True` the slugified entity_ids were colliding (7 sensors all named "Other Consumption" → `_2`/`_3`/.../`_7` suffixes). Verified: 140 dynamic day sensors, 0 duplicate names, 0 duplicate unique_ids. |
| #54 | Prefixed every daily/monthly/yearly/hourly entity reference in `docs/guides/DASHBOARD_GUIDE.md` with `ovo_energy_au_`. Copy-paste examples now resolve. |
| #58 | Bumped `manifest.json` and `info.md` badge to `4.1.1`. After this merges, a `v4.1.1` GitHub Release cut from the merge commit will let HACS resolve the semantic version (was falling back to commit SHA because no tag existed). |

Also adds a `TimestampDataUpdateCoordinator` stub in `tests/conftest.py` so the offline test harness still imports the coordinator.

## Test plan

- [x] `ruff check custom_components/ovo_energy_au/` — clean
- [x] `pytest tests/` — 64 passing (1 pre-existing unrelated failure in `test_ev_usage_tracked`, present on base commit)
- [x] Smoke test: `OVOHealthSensor.extra_state_attributes` returns populated `last_successful_update` without raising
- [x] Smoke test: `_add_dynamic_day_sensors` generates 140 sensors with unique names and unique_ids
- [ ] Merge, then cut `v4.1.1` release tag on the merge commit
- [ ] Verify HACS shows "4.1.1" instead of commit SHA on a live HA install
- [ ] Post-upgrade: users with existing installs should delete the old `_2`/`_3`/... duplicate entities in *Settings → Devices & Services → Entities* so the renamed ones take over

Closes #66, #65, #64, #58, #54. #63 (manual TOU windows for the 3 Free plan) remains open as a feature request on the v4.2 roadmap.

https://claude.ai/code/session_01K6iLxRJrL7Re9H7D45o19Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6iLxRJrL7Re9H7D45o19Q)_