### PR TITLE
Fix flaky test_ev_usage_tracked (unblocks CI)

### DIFF
--- a/custom_components/ovo_energy_au/analytics/hourly.py
+++ b/custom_components/ovo_energy_au/analytics/hourly.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from datetime import datetime, timedelta
 
+from homeassistant.util import dt as dt_util
+
 from ..const import AU_TIMEZONE
 from ..models import PlanConfig
 
@@ -84,8 +86,11 @@ def process_hourly_data(data: dict | None, plan_config: PlanConfig) -> dict:
     # TOU breakdown
     processed["time_of_use"] = _compute_tou_breakdown(timeline)
 
-    # Free and EV usage tracking (Bug 1 fix: use AEST instead of UTC)
-    now_aest = datetime.now(AU_TIMEZONE)
+    # Free and EV usage tracking (Bug 1 fix: use AEST instead of UTC).
+    # Use dt_util.now() so tests can freeze time via the HA mock; astimezone()
+    # ensures month/year comparison always happens in Australian Eastern time
+    # regardless of HA's configured timezone.
+    now_aest = dt_util.now().astimezone(AU_TIMEZONE)
     _add_usage_tracking(processed, timeline, plan_config, now_aest)
 
     # Heatmap


### PR DESCRIPTION
## Summary

Fixes the flaky `test_ev_usage_tracked` that has been failing every CI run since April 1 (it failed on #67 too — see [run 24812019145](https://github.com/HallyAus/OVO_Aus_api/actions/runs/24812019145)).

### Root cause

`analytics/hourly.py` computed `now_aest = datetime.now(AU_TIMEZONE)` (stdlib, not HA's dt_util). `_add_usage_tracking` filters EV entries against `now_aest.month` / `now_aest.year` to compute month-to-date totals. The test fixture uses hard-coded March 2026 timestamps; `conftest.py` mocks `dt_util.now` to return `2026-03-20`, but the stdlib `datetime.now` call **bypasses the mock and uses the real wall clock**. Outside March, the filter excludes every EV entry → `ev_usage["consumption"] == 0` → test fails.

### Fix

Switch to `dt_util.now().astimezone(AU_TIMEZONE)`:

- matches HA convention — always use `dt_util` for time
- the conftest mock now takes effect, making the test deterministic
- `astimezone(AU_TIMEZONE)` guarantees comparison happens in Australian Eastern time regardless of HA's configured TZ (a marginal improvement over previous behaviour)

No production behaviour change for AU-based installs — `dt_util.now()` already returns HA-local time, which for these users is `Australia/Sydney`.

## Test plan

- [x] `pytest tests/` — **65 passed** (was 64 passed / 1 failed on main)
- [x] `ruff check custom_components/ovo_energy_au/` — clean

https://claude.ai/code/session_01K6iLxRJrL7Re9H7D45o19Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6iLxRJrL7Re9H7D45o19Q)_