### PR TITLE
chore(security): add detect-secrets pre-commit hook + redact Auth0 sub

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+repos:
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args:
+          - --baseline
+          - .secrets.baseline
+        exclude: package\.lock\.json|\.ipynb$
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-added-large-files
+        args: [--maxkb=500]
+      - id: check-merge-conflict
+      - id: check-yaml
+        exclude: ^blueprints/
+      - id: check-json
+      - id: end-of-file-fixer
+        exclude: \.svg$
+      - id: trailing-whitespace
+        exclude: \.svg$
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.11
+    hooks:
+      - id: ruff
+        args: [--fix]
+        files: ^custom_components/

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,190 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "package\\.lock\\.json",
+        "\\.ipynb$",
+        "^\\.git/"
+      ]
+    }
+  ],
+  "results": {
+    "custom_components/ovo_energy_au/strings.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "custom_components/ovo_energy_au/strings.json",
+        "hashed_secret": "8be3c943b1609fffbfc51aad666d0a04adf83c9d",
+        "is_verified": false,
+        "line_number": 9
+      }
+    ],
+    "custom_components/ovo_energy_au/translations/en.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "custom_components/ovo_energy_au/translations/en.json",
+        "hashed_secret": "8be3c943b1609fffbfc51aad666d0a04adf83c9d",
+        "is_verified": false,
+        "line_number": 9
+      }
+    ],
+    "custom_components/ovo_energy_au/translations/it.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "custom_components/ovo_energy_au/translations/it.json",
+        "hashed_secret": "8be3c943b1609fffbfc51aad666d0a04adf83c9d",
+        "is_verified": false,
+        "line_number": 9
+      }
+    ],
+    "custom_components/ovo_energy_au/translations/vi.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "custom_components/ovo_energy_au/translations/vi.json",
+        "hashed_secret": "888c9c47cfe0a0fb3c58896221597615a31a6ed1",
+        "is_verified": false,
+        "line_number": 9
+      }
+    ],
+    "docs/guides/BROWSER_TESTING_GUIDE.md": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/guides/BROWSER_TESTING_GUIDE.md",
+        "hashed_secret": "1accfc5cf1446a71facb0470afaa033113490953",
+        "is_verified": false,
+        "line_number": 209
+      }
+    ],
+    "docs/guides/OVO_AU_API_DOCUMENTATION.md": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/guides/OVO_AU_API_DOCUMENTATION.md",
+        "hashed_secret": "1accfc5cf1446a71facb0470afaa033113490953",
+        "is_verified": false,
+        "line_number": 97
+      }
+    ]
+  },
+  "generated_at": "2026-04-23T02:07:03Z"
+}

--- a/docs/guides/BROWSER_TESTING_GUIDE.md
+++ b/docs/guides/BROWSER_TESTING_GUIDE.md
@@ -205,7 +205,7 @@ Go to https://jwt.io and paste tokens to decode:
 ```json
 {
   "iss": "https://login.ovoenergy.com.au/",
-  "sub": "auth0|68e5088a3d30935999afa84a",
+  "sub": "auth0|XXXXXXXXXXXXXXXXXXXXXXXX",
   "aud": "5JHnPn71qgV3LmF3I3xX0KvfRBdROVhR",
   "iat": 1737334000,
   "exp": 1737334300,  // ← 5 minutes later!

--- a/docs/guides/OVO_AU_API_DOCUMENTATION.md
+++ b/docs/guides/OVO_AU_API_DOCUMENTATION.md
@@ -93,7 +93,7 @@ Audience:   Unknown (likely https://api.ovoenergy.com.au)
 ```json
 {
   "iss": "https://login.ovoenergy.com.au/",
-  "sub": "auth0|68e5088a3d30935999afa84a",
+  "sub": "auth0|XXXXXXXXXXXXXXXXXXXXXXXX",
   "aud": "5JHnPn71qgV3LmF3I3xX0KvfRBdROVhR",
   "iat": 1737334000,
   "exp": 1737334300,
@@ -106,7 +106,7 @@ Audience:   Unknown (likely https://api.ovoenergy.com.au)
 ```json
 {
   "iss": "https://login.ovoenergy.com.au/",
-  "sub": "auth0|68e5088a3d30935999afa84a",
+  "sub": "auth0|XXXXXXXXXXXXXXXXXXXXXXXX",
   "aud": "5JHnPn71qgV3LmF3I3xX0KvfRBdROVhR",
   "iat": 1737334000,
   "exp": 1737334300,


### PR DESCRIPTION
## Summary

Follow-up from the full-history secret audit. Repo was clean (no real secrets leaked anywhere), but two optional hardening items came out of it:

1. **Redact the repo owner's personal Auth0 `sub`** from JWT claims examples in `docs/guides/OVO_AU_API_DOCUMENTATION.md` and `docs/guides/BROWSER_TESTING_GUIDE.md`. The sub can't be used to authenticate, but it's PII that has no reason to live in public docs. Replaced with `auth0|XXXXXXXXXXXXXXXXXXXXXXXX`.
2. **Add a `detect-secrets` pre-commit hook** with a reviewed baseline so future commits can't silently leak a credential.

Also wires in a few common pre-commit basics — ruff auto-fix, trailing whitespace, large-file guard, YAML/JSON validity — so contributors get fast local feedback.

### Baseline audit

The `.secrets.baseline` captures 6 known false positives. All reviewed:

| File | What it is |
|---|---|
| `strings.json:9` | `"Password:"` field label in config_flow UI |
| `translations/en.json:9`, `it.json:9`, `vi.json:9` | Same label, localized |
| `docs/guides/BROWSER_TESTING_GUIDE.md:209` | Public OAuth client_id in `aud` claim of JWT example |
| `docs/guides/OVO_AU_API_DOCUMENTATION.md:97` | Same |

No actual secrets in the baseline.

## How contributors opt in

```bash
pip install pre-commit
pre-commit install
```

Subsequent commits auto-run detect-secrets + ruff + hygiene checks.

## Test plan

- [x] `detect-secrets scan` with baseline returns clean
- [x] Baseline entries verified as known-safe false positives
- [x] Docs still render correctly after `sub` redaction

https://claude.ai/code/session_01K6iLxRJrL7Re9H7D45o19Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6iLxRJrL7Re9H7D45o19Q)_