### PR TITLE
fix: per-kWh sensor precision, multi-account balance, reauth error mapping

### DIFF
--- a/custom_components/ovo_energy_au/config_flow.py
+++ b/custom_components/ovo_energy_au/config_flow.py
@@ -85,6 +85,10 @@ async def validate_input(hass: HomeAssistant, username: str, password: str) -> d
             "client": client,  # Return authenticated client to reuse
         }
 
+    except InvalidAuth:
+        # Raised above when no account ID comes back — don't let the generic
+        # handler below re-label it as a connection problem
+        raise
     except OVOEnergyAUApiClientAuthenticationError as err:
         _LOGGER.error("Failed to authenticate with OVO Energy API: %s", err)
         raise InvalidAuth from err

--- a/custom_components/ovo_energy_au/coordinator.py
+++ b/custom_components/ovo_energy_au/coordinator.py
@@ -214,9 +214,15 @@ class OVOEnergyAUDataUpdateCoordinator(TimestampDataUpdateCoordinator):
                 contact_info = await self.client.get_contact_info()
                 accounts = contact_info.get("accounts", [])
                 active = [a for a in accounts if not a.get("closed", False)]
-                if active:
-                    processed["account_balance"] = active[0].get("customerOrientatedBalance")
-                    processed["has_solar"] = active[0].get("hasSolar", False)
+                # Match this entry's account — a multi-account customer must
+                # not see another account's balance (fall back to the first)
+                account = next(
+                    (a for a in active if str(a.get("id")) == str(self.account_id)),
+                    active[0] if active else None,
+                )
+                if account:
+                    processed["account_balance"] = account.get("customerOrientatedBalance")
+                    processed["has_solar"] = account.get("hasSolar", False)
             except OVOEnergyAUApiClientAuthenticationError:
                 raise
             except Exception as err:

--- a/custom_components/ovo_energy_au/sensors/base.py
+++ b/custom_components/ovo_energy_au/sensors/base.py
@@ -76,7 +76,12 @@ class OVOEnergySensor(OVOBaseSensor):
             return None
         try:
             value = self._value_fn(self.coordinator.data)
-            return round(float(value), 2) if value is not None else None
+            if value is None:
+                return None
+            # Per-kWh rates need 4 decimals — 2 would truncate e.g. a
+            # $0.3718/kWh tariff to $0.37 or a 3.3c feed-in tariff to $0.03
+            precision = 4 if self._unit and self._unit.endswith("/kWh") else 2
+            return round(float(value), precision)
         except Exception as err:
             _LOGGER.debug("Sensor %s error: %s", self._sensor_key, err)
             return None

--- a/tests/test_sensor_definitions.py
+++ b/tests/test_sensor_definitions.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from custom_components.ovo_energy_au.sensors.base import OVOEnergySensor
 from custom_components.ovo_energy_au.sensors.definitions import (
     ANALYTICS_SENSORS,
     ENERGY_SENSORS,
@@ -12,6 +13,37 @@ from custom_components.ovo_energy_au.sensors.definitions import (
     calculate_free_savings,
     get_rate_value,
 )
+
+
+class TestSensorStatePrecision:
+    """OVOEnergySensor state precision: 4 decimals for per-kWh rates, 2 otherwise.
+
+    Regression guard: the tariff/cost-per-kWh value_fns return 4-decimal rates
+    (e.g. 0.3718 AUD/kWh), but native_value used to round every sensor to 2
+    decimals, truncating them to 0.37 in HA.
+    """
+
+    def _make_sensor(self, unit, value):
+        coordinator = MagicMock()
+        coordinator.account_id = "12345"
+        coordinator.data = {"present": True}
+        return OVOEnergySensor(
+            coordinator, "test_key", "Test", unit, None, None, "mdi:flash",
+            lambda d: value,
+        )
+
+    def test_per_kwh_rates_keep_4_decimals(self):
+        assert self._make_sensor("AUD/kWh", 0.3718).native_value == 0.3718
+        assert self._make_sensor("AUD/kWh", 0.033).native_value == 0.033
+
+    def test_monetary_rounds_to_2_decimals(self):
+        assert self._make_sensor("AUD", 12.3456).native_value == 12.35
+
+    def test_unitless_rounds_to_2_decimals(self):
+        assert self._make_sensor(None, 1.239).native_value == 1.24
+
+    def test_none_value_is_unavailable(self):
+        assert self._make_sensor("AUD/kWh", None).native_value is None
 
 
 class TestSensorTupleStructure:


### PR DESCRIPTION
Full-codebase review of the integration. Three correctness bugs found and fixed; tests and lint are green (109 passed, ruff clean).

## Fixes

### 1. AUD/kWh sensor states were truncated to 2 decimals (`sensors/base.py`)
`OVOEnergySensor.native_value` rounded every state to 2 decimals, but the tariff/cost-per-kWh value functions deliberately return 4-decimal rates. In HA this truncated:
- Peak Rate: **$0.3718/kWh → $0.37**
- Feed-in Tariff: **$0.033/kWh → $0.03** (a 9% error)
- Overall/Grid/Solar Cost per kWh, Export Rate per kWh — same truncation

Per-kWh units now keep 4 decimals; all other sensors keep the existing 2-decimal behaviour.

### 2. Multi-account customers saw the wrong account balance (`coordinator.py`)
Step 5 of the update loop read `customerOrientatedBalance` / `hasSolar` from `active[0]` — the first active account returned by `GetContactInfo` — rather than the account this config entry is bound to. If a customer has more than one active OVO account (or the API changes account ordering), the Account Balance sensor showed another account's balance. Now matched by `account_id`, falling back to the first active account.

### 3. Reauth error shown as "cannot connect" (`config_flow.py`)
`validate_input` raises `InvalidAuth` when no account ID comes back after authentication, but that raise happened inside its own `try` block, so the trailing `except Exception → CannotConnect` swallowed it and the UI showed a connection error for an auth problem. `InvalidAuth` is now re-raised untouched.

## Tests
- New `TestSensorStatePrecision` class guards fix 1 (4 dp for `*/kWh` units, 2 dp otherwise, `None` stays unavailable).
- `pytest tests/ -q`: **109 passed** · `ruff check`: clean.

## Reviewed but intentionally left alone
- The hourly heatmap / peak-4-hour window include self-consumed solar (total household usage) while the TOU breakdown is grid-only — the code comments show this asymmetry is deliberate.
- `OVOTariffPeriodSensor`'s hardcoded EV-plan schedule (documented limitation).
- `percentOfTotal` fraction-vs-percent heuristic in `_extract_rate_breakdown` — fixture data confirms the API returns fractions, so the heuristic holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016SqhtUmWnS3fevoakjXV3s

---
_Generated by [Claude Code](https://claude.ai/code/session_016SqhtUmWnS3fevoakjXV3s)_